### PR TITLE
Change the tab text color when tab switched

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ Credits
 
  * [Kirill Grouchnikov][1] - Author of [an explanation post on Google+][2]
 
+Updates
+-------
+* Fix the issue of tab text not changed to selected state color
+* Update samples/ with the new `pstsTextSelectedColor` attribute to show Tab text color DOES change when tab switched.
+* Update gradle version to `com.android.tools.build:gradle:1.5.0` 
+* Update android build tool version from `17` to `19` 
 
 License
 =======

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,9 @@
 buildscript {
   repositories {
-    mavenCentral()
+    jcenter()
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:0.4.1'
+    classpath 'com.android.tools.build:gradle:1.5.0'
   }
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -5,8 +5,8 @@ dependencies {
 }
 
 android {
-  compileSdkVersion 17
-  buildToolsVersion '17'
+  compileSdkVersion 19
+  buildToolsVersion '19.1.0'
 
   sourceSets {
     main {

--- a/library/src/com/astuetz/viewpager/extensions/PagerSlidingTabStrip.java
+++ b/library/src/com/astuetz/viewpager/extensions/PagerSlidingTabStrip.java
@@ -420,6 +420,8 @@ public class PagerSlidingTabStrip extends HorizontalScrollView {
 				scrollToChild(pager.getCurrentItem(), 0);
 			}
 
+			updateTabStyles();	
+
 			if (delegatePageListener != null) {
 				delegatePageListener.onPageScrollStateChanged(state);
 			}

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -5,8 +5,8 @@ dependencies {
 }
 
 android {
-  compileSdkVersion 17
-  buildToolsVersion '17'
+  compileSdkVersion 19
+  buildToolsVersion '19.1.0'
 
   sourceSets {
     main {

--- a/sample/res/layout-land/fragment_quick_contact.xml
+++ b/sample/res/layout-land/fragment_quick_contact.xml
@@ -42,6 +42,7 @@
         android:layout_toRightOf="@+id/center"
         android:background="@drawable/background_tabs_diagonal"
         app:dividerColor="#00000000"
+        app:pstsTextSelectedColor="#FF33B5E6"
         app:indicatorColor="#FF33B5E6"
         app:tabPaddingLeftRight="14dip"
         app:underlineColor="#FF33B5E6" />

--- a/sample/res/layout/fragment_quick_contact.xml
+++ b/sample/res/layout/fragment_quick_contact.xml
@@ -32,6 +32,7 @@
         android:background="@drawable/background_tabs_diagonal"
         app:dividerColor="#00000000"
         app:indicatorColor="#FF33B5E6"
+        app:pstsTextSelectedColor="#FF33B5E6"
         app:tabPaddingLeftRight="14dip"
         app:underlineColor="#FF33B5E6" />
 

--- a/sample/src/com/astuetz/viewpager/extensions/sample/MainActivity.java
+++ b/sample/src/com/astuetz/viewpager/extensions/sample/MainActivity.java
@@ -91,6 +91,7 @@ public class MainActivity extends FragmentActivity {
 	private void changeColor(int newColor) {
 
 		tabs.setIndicatorColor(newColor);
+		tabs.setTextSelectedColor(newColor);
 
 		// change ActionBar color just if an ActionBar is available
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {


### PR DESCRIPTION
Add `updateTabStyles()` in the `onPageScrollStateChanged()` callback to make sure text color of tab changed to the `tabTextSelectedColor`.

Also update the sample project to show the result.